### PR TITLE
correct env var names

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ https://tokbox.com/account/user/signup <br>
 
 <h3>Set Environmental Variables inside your vonage_unlocked directory</h3>
 <code> vim .env </code> <br>
-<code>API_KEY = 'Your OpenTok API Key' </code><br>
-<code>API_SECRET = 'Your OpenTok API Secret'</code><br>
+<code>OPENTOK_API = 'Your OpenTok API Key' </code><br>
+<code>OPENTOK_SECRET = 'Your OpenTok API Secret'</code><br>
 <code> :x enter </code> <br>
 </code>
 


### PR DESCRIPTION
the .env file env vars should match app.py so that the app gets the API keys using the expected env var names